### PR TITLE
feat: Linkのラッパーコンポーネント実装

### DIFF
--- a/app/components/custom-link.tsx
+++ b/app/components/custom-link.tsx
@@ -1,0 +1,48 @@
+import { Link as MuiLink, type LinkProps as MuiLinkProps } from "@mui/material";
+import NextLink, { type LinkProps as NextLinkProps } from "next/link";
+import type { JSX } from "react";
+
+type CustomLinkProps = Omit<MuiLinkProps, "href"> & {
+	href: NextLinkProps["href"];
+	unstyled?: boolean;
+};
+
+export function CustomLink({
+	href,
+	unstyled = false,
+	children,
+	...props
+}: Readonly<CustomLinkProps>): JSX.Element {
+	const hrefPath = typeof href === "string" ? href : href.pathname ?? "/";
+	const isInternal = hrefPath.startsWith("/") || hrefPath.startsWith("#");
+
+	if (isInternal) {
+		return (
+			<MuiLink
+				{...props}
+				href={href}
+				component={NextLink}
+				color={unstyled ? "#000" : props.color}
+				underline={unstyled ? "none" : props.underline}
+				sx={props.sx}
+			>
+				{children}
+			</MuiLink>
+		);
+	}
+
+	return (
+		<MuiLink
+			{...props}
+			href={href}
+			component={NextLink}
+			color={unstyled ? "#000" : props.color}
+			underline={unstyled ? "none" : props.underline}
+			sx={props.sx}
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			{children}
+		</MuiLink>
+	);
+}


### PR DESCRIPTION
## ISSUE

close https://github.com/ve1997/nextjs-mui/issues/1

## 確認したこと

- [x] `next/link`の機能を持つ
- [x] ベースのスタイルは`@mui/material/Link`
- [x] 外部リンクかどうかをラッパー側で判断して、必要に応じて`target="_blank"`と`rel="noopener noreferrer"`を付与する
- [x] `unstyled`を指定すると、`color`と`underline`のデフォルトスタイルをリセットできる

